### PR TITLE
Maintenance release, doing some cleaning

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,22 @@
 Revision history
 
+1.12 2021-01-06 feature release, update recommended
+
+- Adjusted VAT rate for Greece (GR/EL) to 24% from 23%
+  This rate changed on June 1st. 2016
+
+- Adjusted VAT rate for Romania (RO) to 19% from 24%
+  This rate changed on January 1st. 2017
+
+- Added missing EU countries to POD: Bulgaria, Croatia and Romania
+
+- Corrected tax rates in POD for multiple countries
+
+- Pointed to GitHub over rt.cpan.org in POD
+
+- Corrected some spelling errors and rephrased a few sentences in the POD
+
+
 1.11 2021-01-04 feature release: "Brexit", update recommended
 
 - Removed UK from list of EU countries

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Business::Tax::VAT - perform European VAT calculations
 
 # VERSION
 
-This pod describes version 1.11
+This pod describes version 1.12
 
 # SYNOPSIS
 
@@ -103,27 +103,30 @@ This module uses the following rates and codes:
 
     at, Austria, 20%
     be, Belgium, 21%
-    cy, Cyprus, 15%
-    cz, Czech Republic, 19%
+    bg, Bulgaria 20%
+    hr, Croatia 25%
+    cy, Cyprus, 19%
+    cz, Czech Republic, 21%
     dk, Denmark, 25%
-    ee, Estonia, 18%
-    fi, Finland, 22%
-    fr, France, 19.6%
+    ee, Estonia, 20%
+    fi, Finland, 24%
+    fr, France, 20%
     de, Germany, 19%
-    gr, Greece, 17.5%
-    hu, Hungary, 25%
-    ie, Ireland, 21%
+    gr, Greece, 24%
+    hu, Hungary, 27%
+    ie, Ireland, 23%
     it, Italy, 22%
-    lv, Latvia, 18%
-    lt, Lithuania, 17.5%
+    lv, Latvia, 21%
+    lt, Lithuania, 21%
     lu, Luxembourg, 17%
     mt, Malta, 18%
-    nl, The Netherlands, 19%
-    pl, Poland, 22%
-    pt, Portugal, 21%
-    sk, Slovak Republic, 19%
-    si, Slovenia, 20%
-    es, Spain, 16%
+    nl, The Netherlands, 21%
+    pl, Poland, 23%
+    pt, Portugal, 23%
+    ro, Romania 19%
+    sk, Slovak Republic, 20%
+    si, Slovenia, 22%
+    es, Spain, 21%
     se, Sweden, 25%
 
 If any of these rates become incorrect, or if you wish to use
@@ -146,16 +149,19 @@ If you want to add your own country, do the following:
 
 # SEE ALSO
 
-- [http://www.vatlive.com/](http://www.vatlive.com/) current and historic VAT rates resource
+- [European Commission Taxes database, search engine](https://ec.europa.eu/taxation_customs/tedb/splSearchForm.html)
+- [Resource for current and historic VAT rates](http://www.vatlive.com/)
 
 # AUTHOR
 
-Tony Bowden
+- Tony Bowden
+- Jonas B. (jonasbn), current maintainer
 
 # BUGS and QUERIES
 
-Please direct all correspondence regarding this module to:
-  bug-Business-Tax-VAT@rt.cpan.org
+Please direct all correspondence regarding this distribution to:
+
+- [GitHub](https://github.com/jonasbn/Business-Tax-VAT/issues)
 
 # ACKNOWLEDGEMENTS
 

--- a/lib/Business/Tax/VAT.pm
+++ b/lib/Business/Tax/VAT.pm
@@ -5,7 +5,7 @@ use warnings;
 use vars qw($VERSION);
 use 5.008;
 
-$VERSION = '1.11';
+$VERSION = '1.12';
 
 =begin markdown
 
@@ -21,7 +21,7 @@ Business::Tax::VAT - perform European VAT calculations
 
 =head1 VERSION
 
-This pod describes version 1.11
+This pod describes version 1.12
 
 =head1 SYNOPSIS
 
@@ -67,7 +67,7 @@ sub _item {
 package Business::Tax::VAT::Price;
 
 use vars qw($VERSION);
-$VERSION = '1.11';
+$VERSION = '1.12';
 
 our %RATE;
 
@@ -86,7 +86,7 @@ sub _calculate_vat_rates {
         es => 21, #spain
         fi => 24, #finland
         fr => 20, #france
-        gr => 23, #greece
+        gr => 24, #greece
         hr => 25, #crotia
         hu => 27, #hungary
         ie => 23, #ireland
@@ -98,7 +98,7 @@ sub _calculate_vat_rates {
         nl => 21, #netherlands
         pl => 23, #poland
         pt => 23, #portugal
-        ro => 24, #romania
+        ro => 19, #romania
         se => 25, #sweden
         si => 22, #slovenia
         sk => 20, #slovakia
@@ -205,27 +205,30 @@ This module uses the following rates and codes:
 
   at, Austria, 20%
   be, Belgium, 21%
-  cy, Cyprus, 15%
-  cz, Czech Republic, 19%
+  bg, Bulgaria 20%
+  hr, Croatia 25%
+  cy, Cyprus, 19%
+  cz, Czech Republic, 21%
   dk, Denmark, 25%
-  ee, Estonia, 18%
-  fi, Finland, 22%
-  fr, France, 19.6%
+  ee, Estonia, 20%
+  fi, Finland, 24%
+  fr, France, 20%
   de, Germany, 19%
-  gr, Greece, 17.5%
-  hu, Hungary, 25%
-  ie, Ireland, 21%
+  gr, Greece, 24%
+  hu, Hungary, 27%
+  ie, Ireland, 23%
   it, Italy, 22%
-  lv, Latvia, 18%
-  lt, Lithuania, 17.5%
+  lv, Latvia, 21%
+  lt, Lithuania, 21%
   lu, Luxembourg, 17%
   mt, Malta, 18%
-  nl, The Netherlands, 19%
-  pl, Poland, 22%
-  pt, Portugal, 21%
-  sk, Slovak Republic, 19%
-  si, Slovenia, 20%
-  es, Spain, 16%
+  nl, The Netherlands, 21%
+  pl, Poland, 23%
+  pt, Portugal, 23%
+  ro, Romania 19%
+  sk, Slovak Republic, 20%
+  si, Slovenia, 22%
+  es, Spain, 21%
   se, Sweden, 25%
 
 If any of these rates become incorrect, or if you wish to use
@@ -250,18 +253,31 @@ If you want to add your own country, do the following:
 
 =over
 
-=item * L<http://www.vatlive.com/> current and historic VAT rates resource
+=item * L<European Commission Taxes database, search engine|https://ec.europa.eu/taxation_customs/tedb/splSearchForm.html>
+
+=item * L<Resource for current and historic VAT rates|http://www.vatlive.com/>
 
 =back
 
 =head1 AUTHOR
 
-Tony Bowden
+=over
+
+=item * Tony Bowden
+
+=item * Jonas B. (jonasbn), current maintainer
+
+=back
 
 =head1 BUGS and QUERIES
 
-Please direct all correspondence regarding this module to:
-  bug-Business-Tax-VAT@rt.cpan.org
+Please direct all correspondence regarding this distribution to:
+
+=over
+
+=item * L<GitHub|https://github.com/jonasbn/Business-Tax-VAT/issues>
+
+=back
 
 =head1 ACKNOWLEDGEMENTS
 


### PR DESCRIPTION
- Adjusted VAT rate for Greece (GR/EL) to 24% from 23%
  This rate changed on June 1st. 2016
- Adjusted VAT rate for Romania (RO) to 19% from 24%
  This rate changed on January 1st. 2017
- Added missing EU countries to POD: Bulgaria, Croatia and Romania
- Corrected tax rates in POD for multiple countries
- Pointed to GitHub over rt.cpan.org in POD
- Corrected some spelling errors and rephrased a few sentences in the POD